### PR TITLE
fix: 修复拖拽后 left 和 top 值

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,8 +85,8 @@ export default class DesignerPlugin extends PureComponent<PluginProps> {
           }
           node.setPropValue('style', {
             position: 'fixed',
-            left,
-            top: loc?.event.canvasY - deltaY,
+            left:left||domNode.style.left,
+            top: (loc?.event.canvasY - deltaY)||domNode.style.top,
           });
 
 


### PR DESCRIPTION
@mark-ck  demo 拖拽后left 值和 top 值无法找到，做了兼容处理